### PR TITLE
use raw posix io to deal with procfs

### DIFF
--- a/linux-namespaces.cabal
+++ b/linux-namespaces.cabal
@@ -23,7 +23,7 @@ source-repository head
 
 library
   exposed-modules:     System.Linux.Namespaces
-  build-depends:       base >=4.6 && <5, unix >=2.6
+  build-depends:       base >=4.6 && <5, unix >=2.6, bytestring >= 0.10
   build-tools:         hsc2hs
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
read/write procfs requires raw POSIX IO. `writeFile` or `BS.writeFile` can cause confusing error such as:

```
/proc/self/uid_map: hClose: permission denied (Operation not permitted)
```

Beside from that, the changes also include:

  - use `System.FilePath` for file path concatenation.
  - fix `/proc/self/gid_map` permission denied issue, because the issue mentioned in `man 7 user_namespaces` (search `proc_setgroups_write`).