### PR TITLE
Support unix prior to 2.8 as well

### DIFF
--- a/System/Linux/Namespaces.hsc
+++ b/System/Linux/Namespaces.hsc
@@ -130,7 +130,11 @@ enterNamespace pid ns =
         setNamespace fd (Just ns)
   where
     openFd' = ioeSetLoc "enterNamespace" $
+#if MIN_VERSION_unix(2,8,0)
         openFd path ReadOnly defaultFileFlags {nonBlock = True}
+#else
+        openFd path ReadOnly Nothing defaultFileFlags {nonBlock = True}
+#endif
     path = toProcPath (Just pid) ns
 
 -- | A unique namespace id.
@@ -215,7 +219,11 @@ writeGroupMappings mpid ms denySetgroups =
 
 writeProcFile :: FilePath -> ByteString -> IO ()
 writeProcFile path bs =
+#if MIN_VERSION_unix(2,8,0)
     bracket (openFd path WriteOnly defaultFileFlags) closeFd $ \fd ->
+#else
+    bracket (openFd path WriteOnly Nothing defaultFileFlags) closeFd $ \fd ->
+#endif
         S.useAsCStringLen bs $ \(ptr, nb) ->
             fdWriteBuf fd (castPtr ptr) (fromIntegral nb) >> return ()
 

--- a/linux-namespaces.cabal
+++ b/linux-namespaces.cabal
@@ -23,7 +23,7 @@ source-repository head
 
 library
   exposed-modules:     System.Linux.Namespaces
-  build-depends:       base >=4.6 && <5, unix >=2.8 && <3.0, bytestring >=0.10 && <1.0
+  build-depends:       base >=4.6 && <5, unix >=2.6 && <3.0, bytestring >=0.10 && <1.0
   build-tools:         hsc2hs
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
via `MIN_VERSION_unix` `CPP` if.

This makes transition easier.